### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ composer require aalaap/faker-youtube
 
 ```php
 $faker = \Faker\Factory::create();
-$faker->addProvider(new Faker\Provider\Youtube($faker));
+$faker->addProvider(new \Faker\Provider\Youtube($faker));
 ```
 
 ```


### PR DESCRIPTION
Fix For  "Class 'Faker\Generator\Provider\Youtube' not found" when trying to run seeds by following ReadMe.
Laravel version: 6.2
Faker version: 1.9.1

Steps to reproduce (fixed) error

1. Install laravel 6.2
2. install package.
3. Setup factory following current ReadMe in master
4. Run seeder